### PR TITLE
fix: 修复 canvas 宽高设置错误问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,8 @@ const setCanvasSize = (): void => {
   canvasEl.width = document.documentElement.clientWidth * 2;
   canvasEl.height = document.documentElement.clientWidth * 2;
   canvasEl.style.width = document.documentElement.clientWidth + "px";
-  canvasEl.style.height = document.documentElement.clientWidth + "px";
+  canvasEl.style.height = document.documentElement.clientHeight + "px";
+
   const ctx = canvasEl.getContext("2d");
   ctx.setTransform(1, 0, 0, 1, 0, 0);
   ctx.scale(2, 2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ let pointerY = 0;
 
 const setCanvasSize = (): void => {
   canvasEl.width = document.documentElement.clientWidth * 2;
-  canvasEl.height = document.documentElement.clientWidth * 2;
+  canvasEl.height = document.documentElement.clientHeight * 2;
   canvasEl.style.width = document.documentElement.clientWidth + "px";
   canvasEl.style.height = document.documentElement.clientHeight + "px";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,10 +23,10 @@ let pointerX = 0;
 let pointerY = 0;
 
 const setCanvasSize = (): void => {
-  canvasEl.width = window.innerWidth * 2;
-  canvasEl.height = window.innerHeight * 2;
-  canvasEl.style.width = window.innerWidth + "px";
-  canvasEl.style.height = window.innerHeight + "px";
+  canvasEl.width = document.documentElement.clientWidth * 2;
+  canvasEl.height = document.documentElement.clientWidth * 2;
+  canvasEl.style.width = document.documentElement.clientWidth + "px";
+  canvasEl.style.height = document.documentElement.clientWidth + "px";
   const ctx = canvasEl.getContext("2d");
   ctx.setTransform(1, 0, 0, 1, 0, 0);
   ctx.scale(2, 2);


### PR DESCRIPTION
在部分情况下，`window.innerWidth`获取到的宽度和实际浏览器可见宽度不同，例如：
![image](https://github.com/D-Sketon/mouse-firework/assets/92242020/9ae62349-8d10-492b-87c2-0af84a2caff2)
此时devtools宽度设置为`464px`，但`window.innerWidth`获取到的为canvas影响后的`530px`

在移动端时，这会导致页面实际宽度大于应显示内容宽度，从而导致响应式设计失效和其他问题

本 PR 通过将其修改为`document.documentElement.clientWidth`修复此问题